### PR TITLE
use relative paths for files in repo, editorial changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
-  [![published](https://static.production.devnetcloud.com/codeexchange/assets/images/devnet-published.svg)](https://developer.cisco.com/codeexchange/github/repo/tekgourou/Cisco-FMC-API-user-context)
+[![published](https://static.production.devnetcloud.com/codeexchange/assets/images/devnet-published.svg)](https://developer.cisco.com/codeexchange/github/repo/tekgourou/Cisco-FMC-API-user-context)
          
-  DESCRIPTION
+# Cisco FMC API User Context
   
-  This python script will give you the ability to manually add or delete a user to IP passive mapping in Cisco FMC. All new mapping will    be save in a DB call db_users_fmc.'YOUR-DOMAIN-NAME'.json. This script leverage the user agent REST API used by the Cisco Terminal Services (TS) Agent. Description of this API can be found here : https://www.cisco.com/c/en/us/td/docs/security/ise/2-2/pic_admin_guide/PIC_admin/PIC_admin_chapter_011.html#id_38498
+This repo contains a Python script that simplifies adding or deleting users from IP passive mapping in Cisco FMC. All new mappings are saved in a database called `db_users_fmc.'YOUR-DOMAIN-NAME'.json`. 
+
+This script leverages the user agent REST API used by the Cisco Terminal Services (TS) Agent. Description of this API can be found [here](https://www.cisco.com/c/en/us/td/docs/security/ise/2-2/pic_admin_guide/PIC_admin/PIC_admin_chapter_011.html#id_38498).
   
 Please contact me at alexandre@argeris.net, if you have any questions or remarks. If you find any bugs, please report them to me, and I will correct them. 
   
-  VARIABLES TO MODIFY BEFORE RUNNING THE SCRIPT
+### VARIABLES TO MODIFY BEFORE RUNNING THE SCRIPT
   
-![image](https://github.com/tekgourou/Cisco-FMC-API-user-context/blob/master/screenshot-variables-to-change.png)  
+![image](./screenshot-variables-to-change.png)  
 
-  EXAMPLES
+### EXAMPLES
   
-  ADDING a user/ip mapping:
-![image](https://github.com/tekgourou/Cisco-FMC-API-user-context/blob/master/screenshot-fire-context-add-user-mapping.png)
+ADDING a user/ip mapping:
+![image](./screenshot-fire-context-add-user-mapping.png)
 
-  DELETING a user/ip mapping:
-![image](https://github.com/tekgourou/Cisco-FMC-API-user-context/blob/master/screenshot-fire-context-delete-user-mapping.png)
+DELETING a user/ip mapping:
+![image](./screenshot-fire-context-delete-user-mapping.png)
   
-  In your FMC you should see the following result :
-![image](https://github.com/tekgourou/Cisco-FMC-API-user-context/blob/master/screenshot-FMC.png)
+In your FMC you should see the following result :
+![image](./screenshot-FMC.png)


### PR DESCRIPTION
In addition to the editorial suggestions, this pull request replaces full paths with relative paths for the various image files in the repo. This is necessary for the links to work properly when people fork or clone the repo.